### PR TITLE
Ignore platform req fix

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,6 +12,10 @@ inputs:
     description: 'Path to composer cache'
     required: true
     default: /tmp/composer-cache
+  ignore-platform-reqs:
+    description: 'What platform requirements should be ignored'
+    required: true
+    default: --ignore-platform-req=ext-gprc
 outputs:
   diff:
     description: "Markdown table with the changed versions"
@@ -21,14 +25,14 @@ runs:
   steps:
     - name: Install dependencies
       shell: bash
-      run: composer install --no-progress --no-scripts --ignore-platform-reqs --no-autoloader -d ${{ inputs.working-dir }}
+      run: composer install --no-progress --no-scripts ${{ inputs.ignore-platform-reqs }} --no-autoloader -d ${{ inputs.working-dir }}
       env:
         COMPOSER_CACHE_DIR: ${{ inputs.composer-cache }}
         COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ inputs.composer-token }}"}}'
 
     - name: Update dependencies
       shell: bash
-      run: composer update --no-progress --no-scripts --ignore-platform-reqs --no-autoloader -d ${{ inputs.working-dir }}
+      run: composer update --no-progress --no-scripts ${{ inputs.ignore-platform-reqs }} --no-autoloader -d ${{ inputs.working-dir }}
       env:
         COMPOSER_CACHE_DIR: ${{ inputs.composer-cache }}
         COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ inputs.composer-token }}"}}'

--- a/action.yaml
+++ b/action.yaml
@@ -12,8 +12,8 @@ inputs:
     description: 'Path to composer cache'
     required: true
     default: /tmp/composer-cache
-  ignore-platform-reqs:
-    description: 'What platform requirements should be ignored'
+  composer-arguments:
+    description: 'Additional composer arguments'
     required: true
     default: --ignore-platform-req=ext-gprc
 outputs:
@@ -25,14 +25,14 @@ runs:
   steps:
     - name: Install dependencies
       shell: bash
-      run: composer install --no-progress --no-scripts ${{ inputs.ignore-platform-reqs }} --no-autoloader -d ${{ inputs.working-dir }}
+      run: composer install --no-progress --no-scripts --no-autoloader -d ${{ inputs.working-dir }} ${{ inputs.composer-arguments }}
       env:
         COMPOSER_CACHE_DIR: ${{ inputs.composer-cache }}
         COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ inputs.composer-token }}"}}'
 
     - name: Update dependencies
       shell: bash
-      run: composer update --no-progress --no-scripts ${{ inputs.ignore-platform-reqs }} --no-autoloader -d ${{ inputs.working-dir }}
+      run: composer update --no-progress --no-scripts --no-autoloader -d ${{ inputs.working-dir }} ${{ inputs.composer-arguments }}
       env:
         COMPOSER_CACHE_DIR: ${{ inputs.composer-cache }}
         COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ inputs.composer-token }}"}}'


### PR DESCRIPTION
`--ignore-platform-reqs` also ignores the php version. Most of the times we use all default PHP dependencies and add grpc. So I think we can safely say to ignore only grpc and most things should remain working. If not then we can add more things to ignore from the calling action.