### PR TITLE
Check outdated

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -16,10 +16,17 @@ inputs:
     description: 'Additional composer arguments'
     required: true
     default: --ignore-platform-req=ext-grpc
+  check-outdated:
+    description: 'Check if we should return the outdated packages'
+    required: true
+    default: '0'
 outputs:
   diff:
     description: "Markdown table with the changed versions"
     value: ${{ steps.get-diff.outputs.diff }}
+  outdated:
+    description: "Script output with the outdated packages that are left after updating"
+    value: ${{ steps.get-outdated.outputs.outdated }}
 runs:
   using: "composite"
   steps:
@@ -38,8 +45,8 @@ runs:
         COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ inputs.composer-token }}"}}'
 
     - name: Create diff
-      shell: bash
       id: get-diff
+      shell: bash
       run: |
         composer global require davidrjonas/composer-lock-diff:^1.0
         diff=$(~/.composer/vendor/bin/composer-lock-diff --md -p ${{ inputs.working-dir }})
@@ -48,4 +55,16 @@ runs:
         diff="${diff//$'\r'/'%0D'}"
         echo "::set-output name=diff::$diff"
       env:
+        COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ inputs.composer-token }}"}}'
+
+    - name: Check outdated
+      id: get-outdated
+      if: ${{ inputs.check-outdated }}
+      shell: bash
+      run: |
+        outdated=$(composer outdated -d ${{ inputs.working-dir }})
+        outdated="${outdated//$'\n'/'\n'}"
+        echo "::set-output name=outdated::$outdated"
+      env:
+        COMPOSER_CACHE_DIR: ${{ inputs.composer-cache }}
         COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ inputs.composer-token }}"}}'

--- a/action.yaml
+++ b/action.yaml
@@ -59,10 +59,9 @@ runs:
 
     - name: Check outdated
       id: get-outdated
-      if: ${{ inputs.check-outdated }}
       shell: bash
       run: |
-        outdated=$(composer outdated -d ${{ inputs.working-dir }})
+        [ "${{ inputs.check-outdated }}" = "1" ] && outdated=$(composer outdated -d ${{ inputs.working-dir }})
         outdated="${outdated//$'\n'/'\n'}"
         echo "::set-output name=outdated::$outdated"
       env:


### PR DESCRIPTION
Calculates which packages are outdated. This should be run after a `composer update` otherwise it'll report packages that are outdated while we didn't merge a PR yet.

Example output:
```
friendsofphp/php-cs-fixer v2.19.0 ~ v3.0.0 A tool to automatically fix PHP code style
php-cs-fixer/diff         v1.3.1  ~ v2.0.2 sebastian/diff v2 backport support for PHP5.6
psr/cache                 1.0.1   ~ 3.0.0  Common interface for caching libraries
psr/container             1.1.1   ~ 2.0.1  Common Container Interface (PHP FIG PSR-11)
```

these are all not updateable because of the major version contraint.